### PR TITLE
Initial commit of TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+dist: bionic
+sudo: required
+
+services:
+- docker
+
+stages:
+  - "make"
+
+branches:
+  only:
+    - master
+
+jobs:
+  include:
+    - stage: "make"


### PR DESCRIPTION
- Adding basic Travis CI to build and push the docker image to [DockerHub](https://hub.docker.com/r/clearmatics/observer-dapp)